### PR TITLE
Add eidas0-mfa and eidas1-mfa ACR support to force-2fa

### DIFF
--- a/.env
+++ b/.env
@@ -17,5 +17,7 @@ ACR_VALUE_FOR_EIDAS3:"eidas3"
 ACR_VALUE_FOR_CONSISTENCY_CHECKED_2FA: "https://proconnect.gouv.fr/assurance/consistency-checked-2fa"
 ACR_VALUE_FOR_SELF_ASSERTED_2FA: "https://proconnect.gouv.fr/assurance/self-asserted-2fa"
 ACR_VALUE_FOR_CERTIFICATION_DIRIGEANT: "https://proconnect.gouv.fr/assurance/certification-dirigeant"
+ACR_VALUE_FOR_EIDAS0_MFA: eidas0-mfa
+ACR_VALUE_FOR_EIDAS1_MFA: eidas1-mfa
 SHOW_BETA_FEATURES: True
 EXTRA_PARAM_SP_NAME: ""

--- a/index.js
+++ b/index.js
@@ -162,6 +162,8 @@ app.post(
             process.env.ACR_VALUE_FOR_EIDAS3,
             process.env.ACR_VALUE_FOR_SELF_ASSERTED_2FA,
             process.env.ACR_VALUE_FOR_CONSISTENCY_CHECKED_2FA,
+            process.env.ACR_VALUE_FOR_EIDAS0_MFA,
+            process.env.ACR_VALUE_FOR_EIDAS1_MFA,
           ],
         },
       },


### PR DESCRIPTION
## Summary

- Add `ACR_VALUE_FOR_EIDAS0_MFA` (`eidas0-mfa`) and `ACR_VALUE_FOR_EIDAS1_MFA` (`eidas1-mfa`) to `.env`
- Include both new ACR values in the accepted `acr.values` list on the `/force-2fa` endpoint

## Why

Extends MFA coverage to eidas0 and eidas1 levels, allowing the test client to request and accept authentication at these assurance levels via the force-2fa flow.

## Test plan

- [ ] Trigger a `/force-2fa` request and verify a successful authentication response