### PR TITLE
⚙️  Update MFA-triggering ACR values structure

### DIFF
--- a/.env
+++ b/.env
@@ -12,12 +12,7 @@ PC_ID_TOKEN_SIGNED_RESPONSE_ALG: RS256
 PC_USERINFO_SIGNED_RESPONSE_ALG: ""
 ACR_VALUES: ""
 SESSION_SECRET: CeciEstUnFauxSecret
-ACR_VALUE_FOR_EIDAS2:"eidas2"
-ACR_VALUE_FOR_EIDAS3:"eidas3"
-ACR_VALUE_FOR_CONSISTENCY_CHECKED_2FA: "https://proconnect.gouv.fr/assurance/consistency-checked-2fa"
-ACR_VALUE_FOR_SELF_ASSERTED_2FA: "https://proconnect.gouv.fr/assurance/self-asserted-2fa"
+ACR_VALUES_FOR_MFA: "eidas2,eidas3,https://proconnect.gouv.fr/assurance/consistency-checked-2fa,https://proconnect.gouv.fr/assurance/self-asserted-2fa"
 ACR_VALUE_FOR_CERTIFICATION_DIRIGEANT: "https://proconnect.gouv.fr/assurance/certification-dirigeant"
-ACR_VALUE_FOR_EIDAS0_MFA: eidas0-mfa
-ACR_VALUE_FOR_EIDAS1_MFA: eidas1-mfa
 SHOW_BETA_FEATURES: True
 EXTRA_PARAM_SP_NAME: ""

--- a/federation.env
+++ b/federation.env
@@ -1,6 +1,6 @@
 HOST: http://localhost:3000
 PORT: 3000
-SITE_TITLE: "Bonjour monde !"
+SITE_TITLE: "Bonjour monde !"
 STYLESHEET_URL: https://unpkg.com/bamboo.css
 CALLBACK_URL: /login-callback
 PC_CLIENT_ID: ef16b50d-ca12-43c4-ac1f-c0a536979457
@@ -10,8 +10,10 @@ PC_SCOPES: "openid given_name usual_name email uid siret idp_id idp_acr"
 LOGIN_HINT: ""
 PC_ID_TOKEN_SIGNED_RESPONSE_ALG: RS256
 PC_USERINFO_SIGNED_RESPONSE_ALG: RS256
-ACR_VALUES: eidas1
+ACR_VALUES: ""
 SESSION_SECRET: CeciEstUnFauxSecret
+ACR_VALUES_FOR_MFA: "eidas2,eidas3,https://proconnect.gouv.fr/assurance/consistency-checked-2fa,https://proconnect.gouv.fr/assurance/self-asserted-2fa"
+ACR_VALUE_FOR_CERTIFICATION_DIRIGEANT: "https://proconnect.gouv.fr/assurance/certification-dirigeant"
 SHOW_BETA_FEATURES: False
 IS_HTTP_PROTOCOL_FORBIDDEN: False
 EXTRA_PARAM_SP_NAME: "ProConnect Test Client"

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const AUTHORIZATION_DEFAULT_PARAMS = {
   redirect_uri: `${process.env.HOST}${process.env.CALLBACK_URL}`,
   scope: process.env.PC_SCOPES,
   login_hint: process.env.LOGIN_HINT || null,
-  acr_values: process.env.ACR_VALUES ? process.env.ACR_VALUES.split(",") : null,
+  acr_values: process.env.ACR_VALUES?.split(",") || null,
   claims: {
     id_token: {
       amr: {
@@ -157,14 +157,7 @@ app.post(
         amr: { essential: true },
         acr: {
           essential: true,
-          values: [
-            process.env.ACR_VALUE_FOR_EIDAS2,
-            process.env.ACR_VALUE_FOR_EIDAS3,
-            process.env.ACR_VALUE_FOR_SELF_ASSERTED_2FA,
-            process.env.ACR_VALUE_FOR_CONSISTENCY_CHECKED_2FA,
-            process.env.ACR_VALUE_FOR_EIDAS0_MFA,
-            process.env.ACR_VALUE_FOR_EIDAS1_MFA,
-          ],
+          values: process.env.ACR_VALUES_FOR_2FA?.split(",") || null,
         },
       },
     },


### PR DESCRIPTION
**Problem**

The current implementation does not allow us to change the number of ACR values that trigger MFA.

**Proposal**

Use a single array-like structure instead of one environment variable per level.

Also update `federation.env` to make it more homogeneous with the default `.env`.