### PR TITLE
⚙️  Use null environment variables instead of empty strings

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 ACR_VALUE_FOR_CERTIFICATION_DIRIGEANT: "https://proconnect.gouv.fr/assurance/certification-dirigeant"
-ACR_VALUES: ""
+ACR_VALUES:
 ACR_VALUES_FOR_MFA: "eidas2,eidas3,https://proconnect.gouv.fr/assurance/consistency-checked-2fa,https://proconnect.gouv.fr/assurance/self-asserted-2fa"
 CALLBACK_URL: /login-callback
 CLIENT_ID: client_id
@@ -8,7 +8,7 @@ EXTRA_PARAM_SP_NAME: ""
 HOST: http://localhost:3000
 ID_TOKEN_SIGNED_RESPONSE_ALG: RS256
 IS_HTTP_PROTOCOL_FORBIDDEN: False
-LOGIN_HINT: ""
+LOGIN_HINT:
 PORT: 3000
 PROVIDER: https://identite-sandbox.proconnect.gouv.fr/
 SCOPES: "openid email profile organization"
@@ -16,4 +16,4 @@ SESSION_SECRET: CeciEstUnFauxSecret
 SHOW_BETA_FEATURES: True
 SITE_TITLE: "Bonjour monde !"
 STYLESHEET_URL: https://unpkg.com/bamboo.css
-USERINFO_SIGNED_RESPONSE_ALG: ""
+USERINFO_SIGNED_RESPONSE_ALG:

--- a/federation.env
+++ b/federation.env
@@ -1,5 +1,5 @@
 ACR_VALUE_FOR_CERTIFICATION_DIRIGEANT: "https://proconnect.gouv.fr/assurance/certification-dirigeant"
-ACR_VALUES: ""
+ACR_VALUES:
 ACR_VALUES_FOR_MFA: "eidas2,eidas3,https://proconnect.gouv.fr/assurance/consistency-checked-2fa,https://proconnect.gouv.fr/assurance/self-asserted-2fa"
 CALLBACK_URL: /login-callback
 CLIENT_ID: ef16b50d-ca12-43c4-ac1f-c0a536979457
@@ -8,7 +8,7 @@ EXTRA_PARAM_SP_NAME: "ProConnect Test Client"
 HOST: http://localhost:3000
 ID_TOKEN_SIGNED_RESPONSE_ALG: RS256
 IS_HTTP_PROTOCOL_FORBIDDEN: False
-LOGIN_HINT: ""
+LOGIN_HINT:
 PORT: 3000
 PROVIDER: https://fca.integ01.dev-agentconnect.fr/api/v2
 SCOPES: "openid given_name usual_name email phone uid siren siret idp_id custom roles organization_label"

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const AUTHORIZATION_DEFAULT_PARAMS = {
   redirect_uri: `${process.env.HOST}${process.env.CALLBACK_URL}`,
   scope: process.env.SCOPES,
   login_hint: process.env.LOGIN_HINT || null,
-  acr_values: process.env.ACR_VALUES ? process.env.ACR_VALUES.split(",") : null,
+  acr_values: process.env.ACR_VALUES?.split(",") || null,
   claims: {
     id_token: {
       amr: {
@@ -157,7 +157,7 @@ app.post(
         amr: { essential: true },
         acr: {
           essential: true,
-          values: process.env.ACR_VALUES_FOR_MFA ? process.env.ACR_VALUES_FOR_MFA.split(",") : null,
+          values: process.env.ACR_VALUES_FOR_MFA?.split(",") || null,
         },
       },
     },


### PR DESCRIPTION
**Problem**

Defaulting unused environment variables to empty strings requires specific handling in the code.

**Proposal**

Do not define unused environment variables, and simplify the code accordingly.